### PR TITLE
support StatBySubPartCalculationPart

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -2,7 +2,7 @@ name: Deploy GitHub Pages
 
 on:
   release:
-    types: [ released ]
+    types: [ published ]
   workflow_dispatch:
 
 permissions:

--- a/example/react/src/components/AstTree.tsx
+++ b/example/react/src/components/AstTree.tsx
@@ -112,22 +112,20 @@ const ValueTreeItem: React.FC<ValueTreeItemProps> = ({ nodeId, value }) => {
               ? [
                   value.stat ? (
                     <TreeItem
+                      key='stat'
                       nodeId={nodeId + '_stat'}
                       label={<TreeItemLabel title={'stat'} text={value.stat} />}
                     />
-                  ) : (
-                    <></>
-                  ),
+                  ) : undefined,
                   value.formula ? (
                     <TreeItem
+                      key='formula'
                       nodeId={nodeId + '_formula'}
                       label={
                         <TreeItemLabel title={'formula'} text={value.formula} />
                       }
                     />
-                  ) : (
-                    <></>
-                  ),
+                  ) : undefined,
                 ]
               : undefined
           }
@@ -155,22 +153,20 @@ const ValueTreeItem: React.FC<ValueTreeItemProps> = ({ nodeId, value }) => {
               ? [
                   value.stat ? (
                     <TreeItem
+                      key='stat'
                       nodeId={nodeId + '_stat'}
                       label={<TreeItemLabel title={'stat'} text={value.stat} />}
                     />
-                  ) : (
-                    <></>
-                  ),
+                  ) : undefined,
                   value.formula ? (
                     <TreeItem
+                      key='formula'
                       nodeId={nodeId + '_formula'}
                       label={
                         <TreeItemLabel title={'formula'} text={value.formula} />
                       }
                     />
-                  ) : (
-                    <></>
-                  ),
+                  ) : undefined,
                 ]
               : undefined
           }
@@ -262,9 +258,7 @@ const GameCalculationTreeItem: React.FC<GameCalculationTreeItemProps> = ({
       ))}
       {gc.percent ? (
         <TreeItem nodeId={nodeId + '_gc_percent'} label='Percent' />
-      ) : (
-        <></>
-      )}
+      ) : undefined}
     </TreeItem>
   );
 };

--- a/src/types/bin.ts
+++ b/src/types/bin.ts
@@ -157,14 +157,30 @@ interface ICalculationPart {
     | 'BuffCounterByCoefficientCalculationPart'
     | 'ByCharLevelBreakpointsCalculationPart'
     | 'ByCharLevelInterpolationCalculationPart'
+    | 'CooldownMultiplierCalculationPart'
     | 'EffectValueCalculationPart'
     | 'NamedDataValueCalculationPart'
     | 'NumberCalculationPart'
     | 'ProductOfSubPartsCalculationPart'
     | 'StatByCoefficientCalculationPart'
     | 'StatByNamedDataValueCalculationPart'
+    | 'StatBySubPartCalculationPart'
     | 'SumOfSubPartsCalculationPart';
 }
+
+export type CalculationPart =
+  | CP_BuffCounterByCoefficient
+  | CP_ByCharLevelBreakpoints
+  | CP_ByCharLevelInterpolation
+  | CP_CooldownMultiplier
+  | CP_EffectValue
+  | CP_NamedDataValue
+  | CP_Number
+  | CP_ProductOfSubParts
+  | CP_StatByCoefficient
+  | CP_StatByNamedDataValue
+  | CP_StatBySubPartCalculationPart
+  | CP_SumOfSubParts;
 
 export interface CP_BuffCounterByCoefficient extends ICalculationPart {
   mBuffName: string;
@@ -189,6 +205,10 @@ export interface CP_ByCharLevelInterpolation extends ICalculationPart {
   __type: 'ByCharLevelInterpolationCalculationPart';
 }
 
+export interface CP_CooldownMultiplier extends ICalculationPart {
+  __type: 'CooldownMultiplierCalculationPart';
+}
+
 export interface CP_EffectValue extends ICalculationPart {
   mEffectIndex: number;
   __type: 'EffectValueCalculationPart';
@@ -210,35 +230,35 @@ export interface CP_ProductOfSubParts extends ICalculationPart {
   __type: 'ProductOfSubPartsCalculationPart';
 }
 
-export interface CP_StatByCoefficient extends ICalculationPart {
+interface ICalculationPartWithStats extends ICalculationPart {
   mStat?: StatType;
   mStatFormula?: StatFormulaType;
+  __type:
+    | 'StatByCoefficientCalculationPart'
+    | 'StatByNamedDataValueCalculationPart'
+    | 'StatBySubPartCalculationPart';
+}
+
+export interface CP_StatByCoefficient extends ICalculationPartWithStats {
   mCoefficient: number;
   __type: 'StatByCoefficientCalculationPart';
 }
 
-export interface CP_StatByNamedDataValue extends ICalculationPart {
-  mStat?: number;
+export interface CP_StatByNamedDataValue extends ICalculationPartWithStats {
   mDataValue: string;
   __type: 'StatByNamedDataValueCalculationPart';
+}
+
+export interface CP_StatBySubPartCalculationPart
+  extends ICalculationPartWithStats {
+  mSubpart: CalculationPart;
+  __type: 'StatBySubPartCalculationPart';
 }
 
 export interface CP_SumOfSubParts extends ICalculationPart {
   mSubparts: CalculationPart[];
   __type: 'SumOfSubPartsCalculationPart';
 }
-
-export type CalculationPart =
-  | CP_BuffCounterByCoefficient
-  | CP_ByCharLevelBreakpoints
-  | CP_ByCharLevelInterpolation
-  | CP_EffectValue
-  | CP_NamedDataValue
-  | CP_Number
-  | CP_ProductOfSubParts
-  | CP_StatByCoefficient
-  | CP_StatByNamedDataValue
-  | CP_SumOfSubParts;
 
 export interface GameCalculation {
   mMultiplier?: CalculationPart;

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -304,12 +304,15 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
       case StatType.MoveSpeed:
         return 'MS';
       case StatType.CritChance:
+        return 'crit chance';
       case StatType.CritDamage:
+        return 'crit damage';
       case StatType.CooldownReduction:
       case StatType.AbilityHaste:
       case StatType.MaxHealth:
         return 'max HP';
       case StatType.CurrentHealth:
+        return 'current HP';
       case StatType.PercentMissingHealth:
       case StatType.Unknown14:
       case StatType.LifeSteal:
@@ -330,6 +333,7 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
       case StatType.Unknown31:
       case StatType.Unknown32:
       case StatType.DodgeChance:
+      default:
         return '?';
     }
   }
@@ -469,16 +473,37 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
     );
   }
 
-  #cp_ProductOfSubParts(cp: CP_ProductOfSubParts): Value {
-    const p1 = this.#cp(cp.mPart1),
-      p2 = this.#cp(cp.mPart2);
-    if (p1.type !== 'Constant' || p2.type !== 'Constant') {
-      console.warn('unsupported sub part in calculation part', cp);
+  #cp_ProductOfSubParts(
+    cp: CP_ProductOfSubParts,
+  ): AbilityLevelValue | ConstantValue {
+    const p1 = this.#cp(cp.mPart1);
+    if (p1.type !== 'Constant') {
+      console.warn('unsupported sub part (1) in calculation part', cp);
       return { value: NaN, type: 'Constant' };
     }
-    return { value: p1.value * p2.value, type: 'Constant' };
+
+    const p2 = this.#cp(cp.mPart2);
+    switch (p2.type) {
+      case 'AbilityLevel':
+        // TODO: should the multiplied value replace the original?
+        return {
+          values: p2.values.map((v) => v * p1.value),
+          type: 'AbilityLevel',
+        };
+      case 'Constant':
+        return {
+          value: p1.value * p2.value,
+          type: 'Constant',
+        };
+    }
+
+    console.warn('unsupported sub part (2) in calculation part', cp);
+    return { value: NaN, type: 'Constant' };
   }
 
+  // TODO: it may not be appropriate to reduce a sum of sub parts to a constant
+  // value.
+  // example: Ashe passive's bonus attack damage.
   #cp_SumOfSubParts(cp: CP_SumOfSubParts): ConstantValue {
     return {
       value: cp.mSubparts.reduce((sum, sp) => {
@@ -504,6 +529,10 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
 
       case 'ByCharLevelInterpolationCalculationPart':
         return this.#cp_ByCharLevelInterpolation(cp);
+
+      case 'CooldownMultiplierCalculationPart':
+        // TODO: is a constant value of 1 appropriate?
+        return this.#value_Constant(1);
 
       case 'EffectValueCalculationPart':
         return this.#cp_EffectValue(cp);
@@ -533,6 +562,18 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
           spell,
           cp.mStat ?? StatType.AbilityPower,
         );
+
+      case 'StatBySubPartCalculationPart':
+        const value = this.#cp(cp.mSubpart, spell);
+        switch (value.type) {
+          case 'Constant':
+            return this.#value_Constant(value.value, cp.mStat, cp.mStatFormula);
+          case 'AbilityLevel':
+            return this.#value_AbilityLevel(value.values, cp.mStat);
+          default:
+            console.warn('unknown sub part', value.type);
+            return { value: NaN, type: 'Constant' };
+        }
 
       default:
         console.warn('unknown formula part', (cp as any).__type);


### PR DESCRIPTION
# Description

- added support for `StatBySubPartCalculationPart`
- added support for `CooldownMultiplierCalculationPart `
- updated `ProductOfSubPartsCalculationPart` to support secondary parts that return `AbilityLevelValue`s

## Issue

N/A

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
