### PR TITLE
Improve sub part rendering

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,8 +1,8 @@
 name: Deploy GitHub Pages
 
 on:
-  release:
-    types: [ created ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:

--- a/example/react/src/components/AstTree.tsx
+++ b/example/react/src/components/AstTree.tsx
@@ -234,6 +234,18 @@ const ValueTreeItem: React.FC<ValueTreeItemProps> = ({ nodeId, value }) => {
           />
         </TreeItem>
       );
+
+    case 'Sum':
+      return (
+        <TreeItem
+          nodeId={nodeId + '_value'}
+          label={<TreeItemLabel title={value.type} />}
+        >
+          {value.values.map((v, i) => (
+            <ValueTreeItem key={i} nodeId={nodeId + '_value_' + i} value={v} />
+          ))}
+        </TreeItem>
+      );
   }
 };
 

--- a/example/react/src/components/AstTree.tsx
+++ b/example/react/src/components/AstTree.tsx
@@ -323,12 +323,13 @@ export const AstTree: React.FC<Props> = ({ ast }) => {
       switch (n.type) {
         case 'Description':
           return (
-            <TreeItem key={n.i} nodeId={nodeId} label='Description'>
+            <TreeItem key={n.i} nodeId={nodeId} label={n.type}>
               {n.children.map(visit)}
             </TreeItem>
           );
         case 'Break':
-          return <TreeItem key={n.i} nodeId={nodeId} label='Break' />;
+        case 'ListItem':
+          return <TreeItem key={n.i} nodeId={nodeId} label={n.type} />;
         case 'Element':
           return (
             <TreeItem

--- a/example/react/src/components/SpellTooltip.tsx
+++ b/example/react/src/components/SpellTooltip.tsx
@@ -63,6 +63,9 @@ const Value: React.FC<ValueProps> = ({ value, percent, precision }) => {
     case 'CharLevelBreakpoints':
       str = toRange(value.values.at(0) ?? 0, value.values.at(-1) ?? 0);
       break;
+    case 'Sum':
+      str = 'TODO';
+      break;
   }
   return <>{str}</>;
 };

--- a/example/react/src/components/SpellTooltip.tsx
+++ b/example/react/src/components/SpellTooltip.tsx
@@ -141,6 +141,7 @@ export const SpellTooltip: React.FC<Props> = ({
         case 'Description':
           return <>{n.children.map(visit)}</>;
         case 'Break':
+        case 'ListItem':
           return <br key={n.i} />;
         case 'Element':
           return (

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -18,6 +18,11 @@ const Break = createToken({
   pattern: /br/,
   longer_alt: Identifier,
 });
+const Li = createToken({
+  name: 'Li',
+  pattern: /li/,
+  longer_alt: Identifier,
+});
 
 const BracketsOpen = createToken({ name: 'BracketsOpen', pattern: /{{/ });
 const BracketsClose = createToken({ name: 'BracketsClose', pattern: /}}/ });
@@ -48,6 +53,7 @@ const tokens = [
   GreaterThan,
   ForwardSlash,
   Break,
+  Li,
 
   BracketsOpen,
   BracketsClose,
@@ -75,6 +81,7 @@ class Parser extends CstParser {
   element!: ParserMethod<unknown[], CstNode>;
   expression!: ParserMethod<unknown[], CstNode>;
   index!: ParserMethod<unknown[], CstNode>;
+  li!: ParserMethod<unknown[], CstNode>;
   multiplier!: ParserMethod<unknown[], CstNode>;
   tagClose!: ParserMethod<unknown[], CstNode>;
   tagOpen!: ParserMethod<unknown[], CstNode>;
@@ -86,13 +93,14 @@ class Parser extends CstParser {
     const $ = this;
 
     // description
-    // : ( text | break | element | expression | template )+
+    // : ( text | break | li | element | expression | template )+
     $.RULE('description', () => {
       $.AT_LEAST_ONE({
         DEF: () => {
           $.OR([
             { ALT: () => $.SUBRULE($.text) },
             { ALT: () => $.SUBRULE($.break) },
+            { ALT: () => $.SUBRULE($.li) },
             { ALT: () => $.SUBRULE($.element) },
             { ALT: () => $.SUBRULE($.expression) },
             { ALT: () => $.SUBRULE($.template) },
@@ -106,6 +114,17 @@ class Parser extends CstParser {
     $.RULE('break', () => {
       $.CONSUME(LessThan);
       $.CONSUME(Break);
+      $.CONSUME(GreaterThan);
+    });
+
+    // li
+    // : "<" "li" ">"
+    //
+    // TODO: capture contents of the list item.
+    // example: Jhin passive.
+    $.RULE('li', () => {
+      $.CONSUME(LessThan);
+      $.CONSUME(Li);
       $.CONSUME(GreaterThan);
     });
 

--- a/src/types/visitor.ts
+++ b/src/types/visitor.ts
@@ -4,6 +4,7 @@ interface IAstNode {
     | 'Description'
     | 'Text'
     | 'Break'
+    | 'ListItem'
     | 'Element'
     | 'Expression'
     | 'Variable'
@@ -15,6 +16,7 @@ export type AstNode =
   | DescriptionNode
   | TextNode
   | BreakNode
+  | ListItemNode
   | ElementNode
   | ExpressionNode
   | VariableNode
@@ -33,6 +35,10 @@ export interface TextNode extends IAstNode {
 
 export interface BreakNode extends IAstNode {
   type: 'Break';
+}
+
+export interface ListItemNode extends IAstNode {
+  type: 'ListItem';
 }
 
 export interface ElementNode extends IAstNode {

--- a/src/types/visitor.ts
+++ b/src/types/visitor.ts
@@ -78,7 +78,12 @@ export interface NumberNode extends IAstNode {
 }
 
 interface IValue {
-  type: 'Constant' | 'AbilityLevel' | 'CharLevel' | 'CharLevelBreakpoints';
+  type:
+    | 'Constant'
+    | 'AbilityLevel'
+    | 'CharLevel'
+    | 'CharLevelBreakpoints'
+    | 'Sum';
 }
 
 interface IValueStats extends IValue {
@@ -90,7 +95,8 @@ export type Value =
   | ConstantValue
   | AbilityLevelValue
   | CharLevelValue
-  | CharLevelBreakpointsValue;
+  | CharLevelBreakpointsValue
+  | SumValue;
 
 export interface ConstantValue extends IValueStats {
   value: number;
@@ -110,6 +116,11 @@ export interface CharLevelValue extends IValue {
 export interface CharLevelBreakpointsValue extends IValue {
   values: number[];
   type: 'CharLevelBreakpoints';
+}
+
+export interface SumValue extends IValue {
+  values: Value[];
+  type: 'Sum';
 }
 
 interface IIdentifier {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -27,6 +27,7 @@ import {
   GameCalculationModified,
   GameCalculationModifiedIdentifier,
   Identifier,
+  ListItemNode,
   NumberNode,
   SpellDataResource,
   SpellObject,
@@ -67,9 +68,7 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
   }
 
   // description
-  // : (
-  //     text | break | element | reference | variable | expression | template
-  //   )+
+  // : ( text | break | li | element | expression | template )+
   description(ctx: CstChildrenDictionary): DescriptionNode {
     return {
       i: -Infinity,
@@ -77,6 +76,7 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
       children: [
         ...(ctx.text ?? []),
         ...(ctx.break ?? []),
+        ...(ctx.li ?? []),
         ...(ctx.element ?? []),
         ...(ctx.reference ?? []),
         ...(ctx.variable ?? []),
@@ -122,6 +122,12 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
   // : "<" "br" ">"
   break(ctx: CstChildrenDictionary): BreakNode {
     return { i: (ctx.LessThan[0] as IToken).startOffset, type: 'Break' };
+  }
+
+  // li
+  // : "<" "li" ">"
+  li(ctx: CstChildrenDictionary): ListItemNode {
+    return { i: (ctx.Li[0] as IToken).startOffset, type: 'ListItem' };
   }
 
   // element

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -505,28 +505,24 @@ export class AstVisitor extends BaseVisitor<undefined, AstNode>() {
   #cp_ProductOfSubParts(
     cp: CP_ProductOfSubParts,
   ): AbilityLevelValue | ConstantValue {
-    const p1 = this.#cp(cp.mPart1);
-    if (p1.type !== 'Constant') {
-      console.warn('unsupported sub part (1) in calculation part', cp);
-      return { value: NaN, type: 'Constant' };
+    const p1 = this.#cp(cp.mPart1),
+      p2 = this.#cp(cp.mPart2);
+
+    if (p1.type === 'AbilityLevel' && p2.type === 'Constant') {
+      return {
+        values: p1.values.map((v) => v * p2.value),
+        type: 'AbilityLevel',
+      };
     }
 
-    const p2 = this.#cp(cp.mPart2);
-    switch (p2.type) {
-      case 'AbilityLevel':
-        // TODO: should the multiplied value replace the original?
-        return {
-          values: p2.values.map((v) => v * p1.value),
-          type: 'AbilityLevel',
-        };
-      case 'Constant':
-        return {
-          value: p1.value * p2.value,
-          type: 'Constant',
-        };
+    if (p1.type === 'Constant' && p2.type === 'AbilityLevel') {
+      return {
+        values: p2.values.map((v) => v * p1.value),
+        type: 'AbilityLevel',
+      };
     }
 
-    console.warn('unsupported sub part (2) in calculation part', cp);
+    console.warn('unsupported sub parts in calculation part', cp);
     return { value: NaN, type: 'Constant' };
   }
 


### PR DESCRIPTION
# Description

- added support for constant value as second sub part of product of sub parts
- added sum value type for values that cannot be summed w/o context (e.g. current champion ability haste)
- added support for parsing spell templates that include `<li>` tags.

## Issue

N/A

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
